### PR TITLE
[foundationdb] Enable transaction log trace

### DIFF
--- a/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
+++ b/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
@@ -39,6 +39,9 @@ public class FoundationDBClient extends DB {
   private int batchSize;
   private int[] batchCounts;
   private boolean setPriorityBatch;
+  private boolean setTransactionTrace;
+  private double transactionTraceFraction;
+  private String debugTransactionIdentifier;
   private static final String API_VERSION                = "foundationdb.apiversion";
   private static final String API_VERSION_DEFAULT        = "630";
   private static final String CLUSTER_FILE               = "foundationdb.clusterfile";
@@ -57,6 +60,14 @@ public class FoundationDBClient extends DB {
   private static final String EXTERNAL_CLIENT_DIRECTORY_DEFAULT = ".";
   private static final String TRACE_DIRECTORY            = "foundationdb.tracedirectory";
   private static final String TRACE_DIRECTORY_DEFAULT    = "";
+  private static final String SET_TRANSACTION_TRACE      = "foundationdb.settransactiontrace";
+  private static final String SET_TRANSACTION_TRACE_DEFAULT = "";
+  private static final String TRANSACTION_TRACE_FRACTION = "foundationdb.transactiontracefraction";
+  private static final String TRANSACTION_TRACE_FRACTION_DEFAULT = "0.0001";
+  private static final String DEBUG_TRANSACTION_IDENTIFIER = "foundationdb.debugtransactionidentifier";
+  private static final String DEBUG_TRANSACTION_IDENTIFIER_DEFAULT = "test";
+  private static final String TRACE_FORMAT               = "foundationdb.traceformat";
+  private static final String TRACE_FORMAT_DEFAULT       = "json";
 
   private Vector<String>[] batchKeys;
   private Vector<Map<String, ByteIterator>>[] batchValues;
@@ -82,8 +93,13 @@ public class FoundationDBClient extends DB {
     String externalClientDirectory
         = props.getProperty(EXTERNAL_CLIENT_DIRECTORY, EXTERNAL_CLIENT_DIRECTORY_DEFAULT);
     String traceDirectory = props.getProperty(TRACE_DIRECTORY, TRACE_DIRECTORY_DEFAULT);
+    String traceFormat = props.getProperty(TRACE_FORMAT, TRACE_FORMAT_DEFAULT);
     logger.info("API Version: {}", apiVersion);
     logger.info("Cluster Files: {}\n", clusterFileString);
+    setTransactionTrace = props.getProperty(SET_TRANSACTION_TRACE, SET_TRANSACTION_TRACE_DEFAULT).equals("true");
+    transactionTraceFraction
+        = Double.parseDouble(props.getProperty(TRANSACTION_TRACE_FRACTION, TRANSACTION_TRACE_FRACTION_DEFAULT));
+    debugTransactionIdentifier = props.getProperty(DEBUG_TRANSACTION_IDENTIFIER, DEBUG_TRANSACTION_IDENTIFIER_DEFAULT);
 
     try {
       synchronized(FoundationDBClient.class) {
@@ -102,6 +118,7 @@ public class FoundationDBClient extends DB {
             if (traceDirectory != TRACE_DIRECTORY_DEFAULT) {
               logger.info("FDB trace directory: {}", traceDirectory);
               fdb.options().setTraceEnable(traceDirectory);
+              fdb.options().setTraceFormat(traceFormat);
             }
           }
         }
@@ -179,9 +196,18 @@ public class FoundationDBClient extends DB {
     return Status.OK;
   }
 
+  private void setupTransactionTraceOptions(Transaction tr, String trIdentifier) {
+    tr.options().setDebugTransactionIdentifier(trIdentifier);
+    tr.options().setLogTransaction();
+    tr.options().setServerRequestTracing();
+  }
+  
   private void batchInsert(int dbIndex) {
     try {
       dbs[dbIndex].run(tr -> {
+          if (setTransactionTrace && Math.random()<transactionTraceFraction) {
+            setupTransactionTraceOptions(tr, debugTransactionIdentifier);
+          }
           for (int i = 0; i < batchCounts[dbIndex]; ++i) {
             String key = batchKeys[dbIndex].get(i);
             Tuple t = new Tuple();
@@ -249,6 +275,9 @@ public class FoundationDBClient extends DB {
           if (setPriorityBatch) {
             tr.options().setPriorityBatch();
           }
+          if (setTransactionTrace && Math.random()<transactionTraceFraction) {
+            setupTransactionTraceOptions(tr, debugTransactionIdentifier);
+          }
           tr.clear(Tuple.from(rowKey).pack());
           return null;
         });
@@ -272,6 +301,9 @@ public class FoundationDBClient extends DB {
       byte[] row = dbs[dbIndex].run(tr -> {
           if (setPriorityBatch) {
             tr.options().setPriorityBatch();
+          }
+          if (setTransactionTrace && Math.random()<transactionTraceFraction) {
+            setupTransactionTraceOptions(tr, debugTransactionIdentifier);
           }
           byte[] r = tr.get(Tuple.from(rowKey).pack()).join();
           return r;
@@ -301,6 +333,9 @@ public class FoundationDBClient extends DB {
       Status s = dbs[dbIndex].run(tr -> {
           if (setPriorityBatch) {
             tr.options().setPriorityBatch();
+          }
+          if (setTransactionTrace && Math.random()<transactionTraceFraction) {
+            setupTransactionTraceOptions(tr, debugTransactionIdentifier);
           }
           byte[] row = tr.get(Tuple.from(rowKey).pack()).join();
           Tuple o = Tuple.fromBytes(row);
@@ -353,6 +388,9 @@ public class FoundationDBClient extends DB {
       tr.options().setReadYourWritesDisable();
       if (setPriorityBatch) {
         tr.options().setPriorityBatch();
+      }
+      if (setTransactionTrace && Math.random()<transactionTraceFraction) {
+        setupTransactionTraceOptions(tr, debugTransactionIdentifier);
       }
       AsyncIterable<KeyValue> entryList = tr.getRange(Tuple.from(startRowKey).pack(), Tuple.from(endRowKey).pack(),
           recordcount > 0 ? recordcount : 0);


### PR DESCRIPTION
This PR enables tracing transaction logs. This is achieved by:
(1) Add transaction trace options when issuing a transaction; 
(2) Set some configuration of this function --- users can open or close the trace via "foundationdb.settransactiontrace" and set the frequency of tracing via "foundationdb.transactiontracefraction";

Pass compile and docker build and test the functionality in AWS env.